### PR TITLE
Fix setting name of v8pp:class_ and prevent context from destroying custom classes on destructor

### DIFF
--- a/v8pp/call_v8.hpp
+++ b/v8pp/call_v8.hpp
@@ -16,6 +16,7 @@ template<typename... Args>
 v8::Local<v8::Value> call_v8(v8::Isolate* isolate, v8::Local<v8::Function> func,
 	v8::Local<v8::Value> recv, Args&&... args)
 {
+	// v8::Isolate::Scope isolate_scope(isolate);
 	v8::EscapableHandleScope scope(isolate);
 
 	int const arg_count = sizeof...(Args);

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -61,6 +61,8 @@ public:
 	{
 		return to_local(isolate_, js_func_);
 	}
+	void set_js_name(std::string_view name) { js_name_ = name; }
+	std::string_view js_name() const { return js_name_; }
 
 	void set_auto_wrap_objects(bool auto_wrap) { auto_wrap_objects_ = auto_wrap; }
 	bool auto_wrap_objects() const { return auto_wrap_objects_; }
@@ -112,6 +114,7 @@ private:
 	ctor_function ctor_;
 	dtor_function dtor_;
 	bool auto_wrap_objects_;
+	std::string js_name_;
 };
 
 class classes
@@ -203,8 +206,7 @@ public:
 			{
 				destroy(isolate, Traits::template static_pointer_cast<T>(obj));
 			}))
-	{
-	}
+	{}
 
 	class_(class_ const&) = delete;
 	class_& operator=(class_ const&) = delete;
@@ -246,6 +248,15 @@ public:
 		class_info_.js_function_template()->Inherit(base.class_function_template());
 		return *this;
 	}
+
+	/// Set the Class Name
+	class_& js_name(std::string_view name)
+	{
+		class_info_.set_js_name(name);
+		class_info_.class_function_template()->SetClassName(to_v8(isolate(), name));
+		return *this;
+	}
+	std::string_view js_name() const { return class_info_.js_name(); }
 
 	/// Enable new C++ objects auto-wrapping
 	class_& auto_wrap_objects(bool auto_wrap = true)

--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -243,7 +243,7 @@ void context::destroy()
 	}
 
 	// remove all class singletons and external data before modules unload
-	cleanup(isolate_);
+	cleanup(isolate_); // In ViciOnline, this should not be the responsibility of a context
 
 	for (auto& kv : modules_)
 	{

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -94,11 +94,11 @@ public:
 
 	/// Set class to the context global object
 	template<typename T, typename Traits>
-	context& class_(std::string_view name, v8pp::class_<T, Traits>& cl)
+	context& class_(v8pp::class_<T, Traits>& cl)
 	{
 		v8::HandleScope scope(isolate_);
-		cl.class_function_template()->SetClassName(v8pp::to_v8(isolate_, name));
-		return value(name, cl.js_function_template()->GetFunction(isolate_->GetCurrentContext()).ToLocalChecked());
+		// cl.class_function_template()->SetClassName(v8pp::to_v8(isolate_, name));
+		return value(cl.js_name(), cl.js_function_template()->GetFunction(isolate_->GetCurrentContext()).ToLocalChecked());
 	}
 
 private:


### PR DESCRIPTION
* The name of a function template must never be set after first instantiation of that function template. Due to how Vici Online is meant to work, this V8PP api was modified for how to set the name of a class_
* Contexts by default in v8pp will destroy all the class data in the isolate. This is undesirable in Vici Online as we want the class data to persist for the lifetime of the program